### PR TITLE
Install miniconda without prompt

### DIFF
--- a/R/0_0_text_install.R
+++ b/R/0_0_text_install.R
@@ -100,7 +100,7 @@ textrpp_install <- function(conda = "auto",
       } else {
         ans <- 2 # When no prompt is set to false, default to install miniconda.
       }
-      if (ans == 2 || prompt ) {
+      if (ans == 2) {
 
         reticulate::install_miniconda(update = update_conda)
         conda <- tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL)

--- a/R/0_0_text_install.R
+++ b/R/0_0_text_install.R
@@ -95,8 +95,12 @@ textrpp_install <- function(conda = "auto",
     # validate that we have conda
     if (!have_conda) {
       cat("No conda was found in the system. ")
-      ans <- utils::menu(c("No", "Yes"), title = "Do you want Text to download miniconda in ~/miniconda?")
-      if (ans == 2) {
+      if (prompt) {
+        ans <- utils::menu(c("No", "Yes"), title = "Do you want Text to download miniconda in ~/miniconda?")
+      } else {
+        ans <- 2 # When no prompt is set to false, default to install miniconda.
+      }
+      if (ans == 2 || prompt ) {
 
         reticulate::install_miniconda(update = update_conda)
         conda <- tryCatch(reticulate::conda_binary("auto"), error = function(e) NULL)


### PR DESCRIPTION
This pull request makes sure that the text package can be installed in non-interactive mode.

It assumes that if the `textrpp_install` is called with the `promt` parameter set to `FALSE` that the user wants miniconda automatically installed.

The problem before was that the function `utils::menu` is not supported when running in non-interactive mode.