### PR TITLE
Fix issue #10. Add `model_max_length` parameter to `textEmbed(LayersOutput)`.

### DIFF
--- a/R/1_1_textEmbed.R
+++ b/R/1_1_textEmbed.R
@@ -227,6 +227,7 @@ grep_col_by_name_in_list <- function(l, pattern) {
 #device = "cpu"
 #print_python_warnings = FALSE
 #tokenizer_parallelism = FALSE
+#model_max_length = NULL
 
 #' Extract layers of hidden states (word embeddings) for all character variables in a given dataframe.
 #' @param x A character variable or a tibble/dataframe with at least one character variable.
@@ -250,6 +251,8 @@ grep_col_by_name_in_list <- function(l, pattern) {
 #' @param print_python_warnings bolean; when TRUE any warnings from python environment are printed
 #'  to the console. (Either way warnings are saved in the comment of the embedding)
 #' @param tokenizer_parallelism If TRUE this will turn on tokenizer parallelism. Default FALSE.
+#' @param model_max_length The maximum length (in number of tokens) for the inputs to the transformer model
+#' (default the value stored for the associated model).
 #' @return A tibble with tokens, column specifying layer and word embeddings. Note that layer 0 is the
 #' input embedding to the transformer, and should normally not be used.
 #' @examples
@@ -271,7 +274,8 @@ textEmbedLayersOutput <- function(x,
                                   return_tokens = TRUE,
                                   device = "cpu",
                                   print_python_warnings = FALSE,
-                                  tokenizer_parallelism = FALSE) {
+                                  tokenizer_parallelism = FALSE,
+                                  model_max_length = NULL) {
 
   # Run python file with HunggingFace interface to state-of-the-art transformers
   reticulate::source_python(system.file("python",
@@ -300,7 +304,8 @@ textEmbedLayersOutput <- function(x,
           layers = layers,
           return_tokens = return_tokens,
           device = device,
-          tokenizer_parallelism = tokenizer_parallelism
+          tokenizer_parallelism = tokenizer_parallelism,
+          model_max_length = model_max_length
         ),
         type = "stderr"
       )
@@ -342,7 +347,8 @@ textEmbedLayersOutput <- function(x,
         layers = layers,
         return_tokens = return_tokens,
         device = device,
-        tokenizer_parallelism = tokenizer_parallelism
+        tokenizer_parallelism = tokenizer_parallelism,
+        model_max_length = model_max_length
       )
     )
 
@@ -563,6 +569,8 @@ textEmbedLayerAggregation <- function(word_embeddings_layers,
 #' such as [CLS] and [SEP] for the decontext embeddings.
 #' @param device Name of device to use: 'cpu', 'gpu', or 'gpu:k' where k is a specific device number
 #' @param print_python_warnings bolean; when true any warnings from python environment are printed to the console.
+#' @param model_max_length The maximum length (in number of tokens) for the inputs to the transformer model
+#' (default the value stored for the associated model).
 #' @return A tibble with tokens, a column for layer identifier and word embeddings.
 #' Note that layer 0 is the input embedding to the transformer
 #' @examples
@@ -595,7 +603,8 @@ textEmbed <- function(x,
                       decontext_tokens_select = NULL,
                       decontext_tokens_deselect = NULL,
                       device = "cpu",
-                      print_python_warnings = FALSE) {
+                      print_python_warnings = FALSE,
+                      model_max_length = NULL) {
   T1_textEmbed <- Sys.time()
 
   reticulate::source_python(system.file("python", "huggingface_Interface3.py", package = "text", mustWork = TRUE))
@@ -608,7 +617,8 @@ textEmbed <- function(x,
     layers = layers,
     return_tokens = FALSE,
     device = device,
-    print_python_warnings = print_python_warnings
+    print_python_warnings = print_python_warnings,
+    model_max_length = model_max_length
   )
 
   # Aggregate context layers

--- a/man/textEmbed.Rd
+++ b/man/textEmbed.Rd
@@ -21,7 +21,8 @@ textEmbed(
   decontext_tokens_select = NULL,
   decontext_tokens_deselect = NULL,
   device = "cpu",
-  print_python_warnings = FALSE
+  print_python_warnings = FALSE,
+  model_max_length = NULL,
 )
 }
 \arguments{
@@ -82,6 +83,9 @@ such as [CLS] and [SEP] for the decontext embeddings.}
 \item{device}{Name of device to use: 'cpu', 'gpu', or 'gpu:k' where k is a specific device number}
 
 \item{print_python_warnings}{bolean; when true any warnings from python environment are printed to the console.}
+
+\item{model_max_length}{The maximum length (in number of tokens) for the inputs to the transformer model
+(default the value stored for the associated model).}
 }
 \value{
 A tibble with tokens, a column for layer identifier and word embeddings.

--- a/man/textEmbedLayersOutput.Rd
+++ b/man/textEmbedLayersOutput.Rd
@@ -13,7 +13,8 @@ textEmbedLayersOutput(
   return_tokens = TRUE,
   device = "cpu",
   print_python_warnings = FALSE,
-  tokenizer_parallelism = FALSE
+  tokenizer_parallelism = FALSE,
+  model_max_length = NULL
 )
 }
 \arguments{
@@ -46,6 +47,9 @@ or all by setting this parameter to "all". Layer 0 is the decontextualized input
 to the console. (Either way warnings are saved in the comment of the embedding)}
 
 \item{tokenizer_parallelism}{If TRUE this will turn on tokenizer parallelism. Default FALSE.}
+
+\item{model_max_length}{The maximum length (in number of tokens) for the inputs to the transformer model
+(default the value stored for the associated model).}
 }
 \value{
 A tibble with tokens, column specifying layer and word embeddings. Note that layer 0 is the


### PR DESCRIPTION
FIx issue #10. Models without a predefined maximum length (e.g., "hfl/chinese-roberta-wwm-ext") can then be used for text  that exceeds the maximum of 512 tokens.

For example, this code results in an error:

```R
text::textEmbedLayersOutput(
	paste(1:600, collapse = " "),
	model = "hfl/chinese-roberta-wwm-ext"
)
```

But the following code works well:

```R
text::textEmbedLayersOutput(
	paste(1:600, collapse = " "),
	model = "hfl/chinese-roberta-wwm-ext",
	model_max_length = 512L
)
```