### PR TITLE
Fix a bug of `textSimilarityTest` (unpaired) & some doc errors

### DIFF
--- a/R/3_2_textSimilarityTest.R
+++ b/R/3_2_textSimilarityTest.R
@@ -6,7 +6,7 @@
 #' @param y Set of word embeddings from textEmbed.
 #' @param similarity_method Character string describing type of measure to be computed; default is "cosine" (see also
 #' measures from textDistance (here computed as 1 - textDistance()) including "euclidean", "maximum", "manhattan", "canberra", "binary" and "minkowski").
-#' @param Npermutations Number of permutations (default 1000).
+#' @param Npermutations Number of permutations (default 10000).
 #' @param method Compute a "paired" or an "unpaired" test.
 #' @param alternative Use a two or one-sided test (select one of: "two_sided", "less", "greater").
 #' @param output.permutations If TRUE, returns permuted values in output.

--- a/R/3_2_textSimilarityTest.R
+++ b/R/3_2_textSimilarityTest.R
@@ -79,7 +79,7 @@ textSimilarityTest <- function(x,
   distribution_mean_ss_permutated <- parallel::mclapply(splitix, function(x, xx, yy) {
     mean_ss_permutated <- sapply(x, function(x, xx, yy) {
       # Get indixes for how to randomly split the word embeddings.
-      indices <- sample(c((rep(TRUE, nrow(x1y1) / 2)), (rep(FALSE, nrow(x1y1) / 2))), nrow(x1y1), replace = FALSE)
+      indices <- sample(c((rep(TRUE, ceiling(nrow(x1y1) / 2))), (rep(FALSE, floor(nrow(x1y1) / 2)))), nrow(x1y1), replace = FALSE)
       # Randomly select word embeddings into two different data frames.
       rdata1 <- x1y1[indices, ]
       rdata2 <- x1y1[!indices, ]

--- a/R/4_1_textPlotCentrality.R
+++ b/R/4_1_textPlotCentrality.R
@@ -90,7 +90,7 @@ textCentrality <- function(words,
 #' @param word_font Type of font (default: NULL).
 #' @param centrality_color_codes Colors of the words selected as plot_n_word_extreme
 #' (minimum values), plot_n_words_middle, plot_n_word_extreme (maximum values) and
-#' plot_n_word_frequency; the default is c("#EAEAEA","#85DB8E", "#398CF9", "#000000"), respectively.
+#' plot_n_word_frequency; the default is c("#EAEAEA", "#85DB8E", "#398CF9", "#9e9d9d", respectively.
 #' @param word_size_range Vector with minimum and maximum font size (default: c(3, 8)).
 #' @param position_jitter_hight Jitter height (default: .0).
 #' @param position_jitter_width Jitter width (default: .03).
@@ -129,7 +129,7 @@ textCentrality <- function(words,
 #' #  x_axes_label = "Semantic Centrality",
 #' #
 #' #  word_font = NULL,
-#' #  centrality_color_codes = c("#EAEAEA","#85DB8E", "#398CF9", "#000000"),
+#' #  centrality_color_codes = c("#EAEAEA", "#85DB8E", "#398CF9", "#9e9d9d"),
 #' #  word_size_range = c(3, 8),
 #' #  point_size = 0.5,
 #' #  arrow_transparency = 0.1,

--- a/man/textCentralityPlot.Rd
+++ b/man/textCentralityPlot.Rd
@@ -71,7 +71,7 @@ change e.g., by trying c(-5, 5)).}
 
 \item{centrality_color_codes}{Colors of the words selected as plot_n_word_extreme
 (minimum values), plot_n_words_middle, plot_n_word_extreme (maximum values) and
-plot_n_word_frequency; the default is c("#EAEAEA","#85DB8E", "#398CF9", "#000000"), respectively.}
+plot_n_word_frequency; the default is c("#EAEAEA", "#85DB8E", "#398CF9", "#9e9d9d"), respectively.}
 
 \item{word_size_range}{Vector with minimum and maximum font size (default: c(3, 8)).}
 
@@ -131,7 +131,7 @@ names(centrality_data_harmony)
 #  x_axes_label = "Semantic Centrality",
 #
 #  word_font = NULL,
-#  centrality_color_codes = c("#EAEAEA","#85DB8E", "#398CF9", "#000000"),
+#  centrality_color_codes = c("#EAEAEA", "#85DB8E", "#398CF9", "#9e9d9d"),
 #  word_size_range = c(3, 8),
 #  point_size = 0.5,
 #  arrow_transparency = 0.1,

--- a/man/textSimilarityTest.Rd
+++ b/man/textSimilarityTest.Rd
@@ -25,7 +25,7 @@ textSimilarityTest(
 \item{similarity_method}{Character string describing type of measure to be computed; default is "cosine" (see also
 measures from textDistance (here computed as 1 - textDistance()) including "euclidean", "maximum", "manhattan", "canberra", "binary" and "minkowski").}
 
-\item{Npermutations}{Number of permutations (default 1000).}
+\item{Npermutations}{Number of permutations (default 10000).}
 
 \item{method}{Compute a "paired" or an "unpaired" test.}
 

--- a/tests/testthat/test_4_textPlot.R
+++ b/tests/testthat/test_4_textPlot.R
@@ -181,7 +181,7 @@ test_that("textCentralityPlot produces a plot.", {
     x_axes_label = "Semantic Centrality",
 
     word_font = NULL,
-    centrality_color_codes = c("#EAEAEA", "#85DB8E", "#398CF9", "#000000"),
+    centrality_color_codes = c("#EAEAEA", "#85DB8E", "#398CF9", "#9e9d9d"),
     word_size_range = c(3, 8),
     point_size = 0.5,
     arrow_transparency = 0.1,


### PR DESCRIPTION
Currently this code runs without any problem:

```R
text::textSimilarityTest(
	x = text::word_embeddings_4$harmonywords[1:5,],
	y = text::word_embeddings_4$satisfactionwords[1:5,],
	method = "unpaired",
	Npermutations = 100,
	N_cluster_nodes = 1,
	alternative = "two_sided"
)

text::textSimilarityTest(
	x = text::word_embeddings_4$harmonywords[1:5,],
	y = text::word_embeddings_4$satisfactionwords[1:7,],
	method = "unpaired",
	Npermutations = 100,
	N_cluster_nodes = 1,
	alternative = "two_sided"
)
```

But the following code results in an error:

```R
text::textSimilarityTest(
	x = text::word_embeddings_4$harmonywords[1:5,],
	y = text::word_embeddings_4$satisfactionwords[1:6,],
	method = "unpaired",
	Npermutations = 100,
	N_cluster_nodes = 1,
	alternative = "two_sided"
)
```

It is because `length(c((rep(TRUE, nrow(x1y1) / 2)), (rep(FALSE, nrow(x1y1) / 2))))` can be smaller than `nrow(x1y1))` when `nrow(x1y1))` is an odd number.

---

I'm not sure whether the default of the `Npermutations` parameter of `textSimilarityTest`  should be 1000 or 10000. The doc says it's 1000 but the code uses 10000.