### PR TITLE
Allow cased embeddings in textPCA

### DIFF
--- a/R/0_2_privateFunctions.R
+++ b/R/0_2_privateFunctions.R
@@ -4,9 +4,9 @@
 #' @return Column with all words and an accompanying column with their frequency.
 #' @importFrom tibble as_tibble
 #' @noRd
-unique_freq_words <- function(words) {
+unique_freq_words <- function(words, tolower = TRUE) {
   # Make all words lower case
-  words <- tolower(words)
+  if(tolower) words <- tolower(words)
 
   # separate words/tokens combined with /
   words <- gsub("/", " ", words)

--- a/R/4_2_textPlotPCA.R
+++ b/R/4_2_textPlotPCA.R
@@ -33,8 +33,9 @@ textPCA <- function(words,
   set.seed(seed)
   # PCA on word_types_embeddings
   # Select word embeddings to be included in plot
-  uniques_words_all <- unique_freq_words(words)
-  uniques_words_all_wordembedding <- sapply(uniques_words_all$words, applysemrep, word_types_embeddings)
+  no_upcase_embedding_words <- !any(grepl("[A-Z]", word_types_embeddings$words))
+  uniques_words_all <- unique_freq_words(words, tolower = no_upcase_embedding_words)
+  uniques_words_all_wordembedding <- sapply(uniques_words_all$words, applysemrep, word_types_embeddings, tolower = no_upcase_embedding_words)
   uniques_words_all_wordembedding <- tibble::as_tibble(t(uniques_words_all_wordembedding))
 
   rec_pca <- recipes::recipe(~., data = uniques_words_all_wordembedding)


### PR DESCRIPTION
Previous version always converts to lower case in unique_freq_words and only works with uncased models. This pull request adds a tolower parameter and sets it according to whether any embedding words include upper case letters.