### PR TITLE
model_reference integrated into model_info + changed model loading system + additional fixes

### DIFF
--- a/R/0_2_privateFunctions.R
+++ b/R/0_2_privateFunctions.R
@@ -511,6 +511,10 @@ implicit_motives_results <- function(model_reference,
     column_name <- model_reference
   }
   
+  if (length(texts) != length(user_id)) {
+    stop('texts and user_id must be of same length.')
+  }
+  
   # Retrieve Data
   implicit_motives <- implicit_motives(texts, user_id, predicted_scores2)
   
@@ -535,4 +539,25 @@ implicit_motives_results <- function(model_reference,
   
   return(summary_list)
 }
+
+# Function to expand predictions and bind them to the data
+bind_predictions <- function(data, predictions) {
+  na_rows <- max(0, nrow(data) - nrow(predictions))
+  dplyr::bind_rows(predictions,
+                   tibble::as_tibble(matrix(NA, 
+                                            ncol = ncol(predictions), 
+                                            nrow = na_rows)) %>%
+                     setNames(names(predictions)))
+}
+
+# Function to bind original data with a list of tibbles
+bind_data <- function(original_data, prediction_list) {
+  for(predictions in prediction_list) {
+    original_data <- dplyr::bind_cols(original_data, bind_predictions(original_data, predictions))
+  }
+  original_data
+}
+
+# Usage example (replace with actual tibble names)
+# final_data <- bind_data(data, list(tibble1, tibble2))
 

--- a/R/0_2_privateFunctions.R
+++ b/R/0_2_privateFunctions.R
@@ -349,13 +349,14 @@ path_exist_download_files <- function(wanted_file) {
 #' @noRd
 implicit_motives <- function(texts, user_id, predicted_scores2){
   
-  # Create a table with the number of sentences per user 
+  # Create a table with the number of sentences per user
   table_uniques2 <- table(user_id[1:dim(predicted_scores2)[1]])
   num_persons <- length(table_uniques2)
   
   # Define variables 
   user_id_column <- c()
   current <- 0
+  
   # Create user_id_column
   for (i in 1:num_persons) {
     current <- current + table_uniques2[[i]]
@@ -372,8 +373,8 @@ implicit_motives <- function(texts, user_id, predicted_scores2){
   
   # Summarize classes and probabilities (for the first row)
   summations[1, c("OUTCOME_USER_SUM_CLASS", "OUTCOME_USER_SUM_PROB")] <- c(
-    OUTCOME_USER_SUM_CLASS = sum(as.numeric(predicted_scores2[[1]][1:table_uniques2[[1]]]), na.rm = TRUE),
-    OUTCOME_USER_SUM_PROB = sum(as.numeric(predicted_scores2[[3]][1:table_uniques2[[1]]]), na.rm = TRUE)
+    OUTCOME_USER_SUM_CLASS = sum(as.numeric(as.character(predicted_scores2[[1]][1:table_uniques2[[1]]])), na.rm = TRUE),
+    OUTCOME_USER_SUM_PROB = sum(as.numeric(as.character(predicted_scores2[[3]][1:table_uniques2[[1]]])), na.rm = TRUE)
   )
   
   # Summarize classes and probabilities (for the rest of the rows)
@@ -382,10 +383,12 @@ implicit_motives <- function(texts, user_id, predicted_scores2){
     end_idx <- sum(table_uniques2[1:user_ids])
     
     summations[user_ids, c("OUTCOME_USER_SUM_CLASS", "OUTCOME_USER_SUM_PROB")] <- c(
-      OUTCOME_USER_SUM_CLASS = sum(as.numeric(predicted_scores2[[1]][start_idx:end_idx]), na.rm = TRUE),
-      OUTCOME_USER_SUM_PROB = sum(as.numeric(predicted_scores2[[3]][start_idx:end_idx]), na.rm = TRUE)
+      OUTCOME_USER_SUM_CLASS = sum(as.numeric(as.character(predicted_scores2[[1]][start_idx:end_idx])), na.rm = TRUE),
+      OUTCOME_USER_SUM_PROB = sum(as.numeric(as.character(predicted_scores2[[3]][start_idx:end_idx])), na.rm = TRUE)
     )
   }
+  
+
   
   # Calculate wc_person_per_1000 (for the first row)
   summations[1, "wc_person_per_1000"] <- sum(lengths(strsplit(texts[1:table_uniques2[[1]]], ' ')), na.rm = TRUE) / 1000
@@ -400,6 +403,8 @@ implicit_motives <- function(texts, user_id, predicted_scores2){
   }
   
   summations["user_ids"] <- user_id_column
+  
+  
   return(summations)
 }
 
@@ -408,13 +413,15 @@ implicit_motives <- function(texts, user_id, predicted_scores2){
 #' @return implicit_motives_pred returns residuals from robust linear regression. 
 #' @noRd
 implicit_motives_pred <- function(sqrt_implicit_motives){
+  
   #square root transform
-  sqrt_implicit_motives[1:3] <- sqrt(sqrt_implicit_motives[1:3])
+  sqrt_implicit_motives[c("OUTCOME_USER_SUM_CLASS", "OUTCOME_USER_SUM_PROB", "wc_person_per_1000")] <- sqrt(sqrt_implicit_motives[c("OUTCOME_USER_SUM_CLASS", "OUTCOME_USER_SUM_PROB", "wc_person_per_1000")])
+  
   # For OUTCOME_USER_SUM_PROB
   lm.OUTCOME_USER_SUM_PROB <- stats::lm(OUTCOME_USER_SUM_PROB  ~ wc_person_per_1000, data = sqrt_implicit_motives)
   OUTCOME_USER_SUM_PROB.residual1 <- resid(lm.OUTCOME_USER_SUM_PROB)
   OUTCOME_USER_SUM_PROB.residual1.z <- scale(OUTCOME_USER_SUM_PROB.residual1)
-  
+
   # For OUTCOME_USER_SUM_CLASS
   lm.OUTCOME_USER_SUM_CLASS <- stats::lm(OUTCOME_USER_SUM_CLASS  ~ wc_person_per_1000, data = sqrt_implicit_motives)
   OUTCOME_USER_SUM_CLASS.residual1 <- resid(lm.OUTCOME_USER_SUM_CLASS)
@@ -426,7 +433,7 @@ implicit_motives_pred <- function(sqrt_implicit_motives){
     person_prob = as.vector(OUTCOME_USER_SUM_PROB.residual1.z),
     person_class = as.vector(OUTCOME_USER_SUM_CLASS.residual1.z)
   )
-  
+
   return(implicit_motives_pred)
 }
 
@@ -518,7 +525,7 @@ implicit_motives_results <- function(model_reference,
   # Retrieve Data
   implicit_motives <- implicit_motives(texts, user_id, predicted_scores2)
   
-  # Predict 
+  # Predicts
   predicted <- implicit_motives_pred(implicit_motives)
   
   # Full column name
@@ -540,7 +547,58 @@ implicit_motives_results <- function(model_reference,
   return(summary_list)
 }
 
-# Function to expand predictions and bind them to the data
+#' Function that is called in the beginning of textPredict to create the conditions for implicit motives to work. 
+#' @param model_infomodel_info (character or r-object) model_info has three options. 1: R model object (e.g, saved output from textTrain). 2:link to github-model 
+#' (e.g, "https://github.com/CarlViggo/pretrained_swls_model/raw/main/trained_github_model_logistic.RDS"). 3: Path to a model stored locally (e.g, "path/to/your/model"). 
+#' @param user_id A column with user ids. 
+#' @param show_texts Show texts, TRUE / FALSE 
+#' @return Returns a list of conditions for implicit motive coding to work
+#' @noRd
+get_model_info <- function(model_info, user_id, show_texts, type) {
+  # Show_prob is by default FALSE
+  show_prob <- FALSE
+  if (is.character(model_info)){
+  lower_case_model <- tolower(model_info)
+    if (
+      grepl("power", lower_case_model) ||
+      grepl("achievement", lower_case_model) ||
+      grepl("affiliation", lower_case_model) && !is.null(user_id)
+    ) {
+      type <- "class"  # type must be class for these conditions
+      
+      # Switch to the correct model URL
+      if (lower_case_model == "power") {
+        model_info <- "https://github.com/AugustNilsson/Implicit-motive-models/releases/download/implicit-motive-model/schone5k_rob_la_l23_to_power_pen_30.rds"
+        } else if (lower_case_model == "achievement") {
+        model_info <- "https://github.com/AugustNilsson/Implicit-motive-models/releases/download/implicit-motive-model/schone5k_rob_la_l23_to_achievement_pen_30.rds"
+      } else if (lower_case_model == "affiliation") {
+        model_info <- "https://github.com/AugustNilsson/Implicit-motive-models/releases/download/implicit-motive-model/schone5k_rob_la_l23_to_affiliation_pen_30.rds"
+      }
+  
+      # Specific configuration for implicit motive coding
+      if (!is.null(user_id)){
+        show_texts <- TRUE 
+        show_prob <- TRUE 
+        type <- "class"
+      }
+    }
+  }
+  
+  # The stats package just takes "class" or "prob", therefore, allocate to "show_prob". 
+  if (!is.null(type) && type == "class_prob") {
+    type = "class"
+    show_prob = TRUE
+  }
+  
+  # Return a list containing the required information
+  return(list(model_info = model_info, type = type, show_texts = show_texts, show_prob = show_prob, type = type))
+}
+
+#' Function that binds predictions to their original dataset
+#' @param data Dataset, ex csv file
+#' @param predictions Predictions from textPredict as a vector
+#' @return Returns the original dataset with predictions included. 
+#' @noRd
 bind_predictions <- function(data, predictions) {
   na_rows <- max(0, nrow(data) - nrow(predictions))
   dplyr::bind_rows(predictions,

--- a/R/2_4_textPredict.R
+++ b/R/2_4_textPredict.R
@@ -539,9 +539,9 @@ textPredictAll <- function(models,
   # i = 1
   for (i in seq_len(length(models))) {
     preds <- textPredict(
-      models[[i]],
-      word_embeddings,
-      x_append, ...
+      model_info = models[[i]],
+      word_embeddings = word_embeddings,
+      x_append = x_append, ...
     )
     
     output_predictions[[i]] <- preds

--- a/man/textPredict.Rd
+++ b/man/textPredict.Rd
@@ -2,22 +2,17 @@
 % Please edit documentation in R/2_4_textPredict.R
 \name{textPredict}
 \alias{textPredict}
-\title{Trained models created by e.g., textTrain() or strored on e.g., github can be used to predict new scores or classes from embeddings or text using textPredict.}
+\title{Trained models created by e.g., textTrain() or stored on e.g., github can be used to predict new scores or classes from embeddings or text using textPredict.}
 \usage{
 textPredict(
   model_info = NULL,
   word_embeddings = NULL,
+  texts = NULL,
   x_append = NULL,
   type = NULL,
   dim_names = TRUE,
-  texts = NULL,
-  model_platform = "github",
-  model_reference =
-    "https://github.com/CarlViggo/pretrained-models/raw/main/trained_hils_model.RDS",
-  save_model = FALSE,
-  model_name = NULL,
+  save_model = TRUE,
   threshold = NULL,
-  show_prob = FALSE,
   show_texts = FALSE,
   device = "cpu",
   user_id = NULL,
@@ -26,36 +21,25 @@ textPredict(
 )
 }
 \arguments{
-\item{model_info}{(model object) Model info (e.g., saved output from textTrain,
-textTrainRegression or textRandomForest).}
+\item{model_info}{(character or r-object) model_info has three options. 1: R model object (e.g, saved output from textTrain). 2:link to github-model 
+(e.g, "https://github.com/CarlViggo/pretrained_swls_model/raw/main/trained_github_model_logistic.RDS"). 3: Path to a model stored locally (e.g, "path/to/your/model").}
 
-\item{word_embeddings}{(tibble) Embeddings from e.g., textEmbed(). If you're using a premade model, then submit either texts or word_embeddings (default = NULL).}
+\item{word_embeddings}{(tibble) Embeddings from e.g., textEmbed(). If you're using a pretrained model, then texts and embeddings cannot be submitted simultaneously (default = NULL).}
+
+\item{texts}{(character) Text to predict. If this argument is specified, then arguments "word_embeddings" and "premade embeddings" cannot be defined (default = NULL).}
 
 \item{x_append}{(tibble) Variables to be appended after the word embeddings (x).}
 
-\item{type}{(character) Defines the type of prediction when implementing logistic models. Either probabilities or
-classifications are returned (default = "class". For probabilities use "prob").}
+\item{type}{(character) Defines what output to give after logistic regression prediction. Either probabilities, 
+classifications or both are returned (default = "class". For probabilities use "prob". For both use "class&prob").}
 
 \item{dim_names}{(boolean) Account for specific dimension names from textEmbed()
 (rather than generic names including Dim1, Dim2 etc.). If FALSE the models need to have been trained on
 word embeddings created with dim_names FALSE, so that embeddings were only called Dim1, Dim2 etc.}
 
-\item{texts}{(character) Text to predict. If this argument is specified, then arguments "word_embeddings" and "premade embeddings" cannot be defined (default = NULL).}
-
-\item{model_platform}{(character) Either "github" or "local" (default = "github").}
-
-\item{model_reference}{(character) Link to github-model (default = "https://github.com/CarlViggo/pretrained_swls_model/raw/main/trained_github_model_logistic.RDS",
-a model that predicts harmony in life score).}
-
-\item{save_model}{(boolean) If set to true, the model will be saved to the work-directory (default = FALSE). If TRUE, then argument "model_name" must be defined.}
-
-\item{model_name}{(character) Optional. If the 'save_model' argument is set to TRUE and you wish to assign a custom name to your model, 
-provide a file path along with the desired filename, for example, 'C:/Users/Name/Models/linear_model.RDS' (default is NULL). If this is not defined 
-but 'save_model' is set to TRUE, the model will be saved as 'imported_model.RDS'.}
+\item{save_model}{(boolean) The model will by default be saved in your work-directory (default = TRUE). If the model already exists in your work-directory, it will automatically be loaded from there.}
 
 \item{threshold}{(numeric) Determine threshold if you are using a logistic model (default = 0.5).}
-
-\item{show_prob}{(boolean) If you are using a logistic model and show_prob is set to TRUE, then both classification and the underlying probabilities will be}
 
 \item{show_texts}{(boolean) Show texts together with predictions (default = FALSE).}
 
@@ -74,7 +58,7 @@ word-embedding per story-id will be calculated. (default = NULL)}
 Predictions from word-embedding or text input.
 }
 \description{
-Trained models created by e.g., textTrain() or strored on e.g., github can be used to predict new scores or classes from embeddings or text using textPredict.
+Trained models created by e.g., textTrain() or stored on e.g., github can be used to predict new scores or classes from embeddings or text using textPredict.
 }
 \examples{
 
@@ -83,33 +67,27 @@ Trained models created by e.g., textTrain() or strored on e.g., github can be us
 # Text data from Language_based_assessment_data_8
 text_to_predict = "I am not in harmony in my life as much as I would like to be." 
 
-# Example 1: (predict using embeddings and local model)
+# Example 1: (predict using pre-made embeddings and an R model-object)
 prediction1 <- textPredict(trained_model, 
                            word_embeddings_4$texts$satisfactiontexts)
 
 # Example 2: (predict using a pretrained github model)
-prediction2 <- textPredict(texts = text_to_predict)
-
-# Example 4: (predict using a pretrained github model and save the model locally)
 prediction3 <- textPredict(texts = text_to_predict, 
-                            model_platform = "github", 
-                            model_reference = "https://github.com/CarlViggo/pretrained-models/raw/main/trained_hils_model.RDS",
-                            save_model = TRUE)
+                           model_info = "https://github.com/CarlViggo/pretrained-models/raw/main/trained_hils_model.RDS")
                            
-# Example 5: (predict using a pretrained logistic github model and return probabilities and classifications simultaneously)
+# Example 3: (predict using a pretrained logistic github model and return probabilities and classifications)
 prediction4 <- textPredict(texts = text_to_predict, 
-                            model_reference = "https://github.com/CarlViggo/pretrained-models/raw/main/trained_github_model_logistic.RDS",
-                            type = "class",
-                            threshold = 0.7, 
-                            show_prob = TRUE)
+                           model_info = "https://github.com/CarlViggo/pretrained-models/raw/main/trained_github_model_logistic.RDS",
+                           type = "class&prob",
+                           threshold = 0.7)
                        
-# Example 6: (Automatic implicit motive coding)
+# Example 4: (Automatic implicit motive coding with story_id concatenation)
 schone_training <- read.RDS("schone_training.rds")
 
 implicit_motives <- textPredict(texts = schone_training$text,
-                                 model_reference = "power",
-                                 user_id = schone_training$participant_id, 
-                                 story_id = schone_training$story_id) 
+                                model_info = "power",
+                                user_id = schone_training$participant_id, 
+                                story_id = schone_training$story_id) 
 }
 
 \dontrun{

--- a/man/textPredict.Rd
+++ b/man/textPredict.Rd
@@ -31,7 +31,7 @@ textPredict(
 \item{x_append}{(tibble) Variables to be appended after the word embeddings (x).}
 
 \item{type}{(character) Defines what output to give after logistic regression prediction. Either probabilities, 
-classifications or both are returned (default = "class". For probabilities use "prob". For both use "class&prob").}
+classifications or both are returned (default = "class". For probabilities use "prob". For both use "class_prob").}
 
 \item{dim_names}{(boolean) Account for specific dimension names from textEmbed()
 (rather than generic names including Dim1, Dim2 etc.). If FALSE the models need to have been trained on
@@ -78,7 +78,7 @@ prediction3 <- textPredict(texts = text_to_predict,
 # Example 3: (predict using a pretrained logistic github model and return probabilities and classifications)
 prediction4 <- textPredict(texts = text_to_predict, 
                            model_info = "https://github.com/CarlViggo/pretrained-models/raw/main/trained_github_model_logistic.RDS",
-                           type = "class&prob",
+                           type = "class_prob",
                            threshold = 0.7)
                        
 # Example 4: (Automatic implicit motive coding with story_id concatenation)


### PR DESCRIPTION
Model_info and model_reference are merged to become model_info. That is, model_info now accepts R-objects, links to the model on github, and local file paths. The arguments model_name and model_platform are removed; this is now handled automatically.

show_prob is merged with type. Type can now be "class", "prob", or "class_prob" where "class_prob" means that both class and probability are shown in logistic regression.

Additionally, if the user specifies a github link, the function first checks if the model exists in the working directory (wd). If it does, the model is loaded from the wd (locally) and not from github,  reducing the loading time. Otherwise, the model is downloaded locally and then read.