### PR TITLE
use named `title.theme`

### DIFF
--- a/R/4_2_textPlotPCA.R
+++ b/R/4_2_textPlotPCA.R
@@ -315,7 +315,7 @@ textPCAPlot <- function(word_data,
         title.position = "top",
         direction = "horizontal",
         label.position = "bottom",
-        ggplot2::element_text(color = titles_color)
+        title.theme = ggplot2::element_text(color = titles_color)
       )
     ) +
 


### PR DESCRIPTION
Hi there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break text.

The apparent cause of the breakage was an unnamed argument to `guide_legend()`. The guides in general have had a major overhaul and these styling options like `title.theme` are deprecated. There is a fallback for backwards compatibility, but this fallback only works with named arguments.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help text get out a fix if necessary.
