### PR TITLE
Look for HUGGINGFACE_TOKEN environment variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: text
 Type: Package
 Title: Analyses of Text using Transformers Models from HuggingFace, Natural Language Processing and Machine Learning
-Version: 1.2.0.07
+Version: 1.2.0.08
 Authors@R: c(
     person("Oscar", "Kjell", , "oscar.kjell@psy.lu.se", role = c("aut", "cre"), 
       comment = c(ORCID = "0000-0002-2728-6278"),

--- a/R/0_3_textModels.R
+++ b/R/0_3_textModels.R
@@ -23,7 +23,10 @@ textModels <- function() {
 #' Get the number of layers in a given model.
 #' @param target_model (string) The name of the model to know the number of layers of.
 #' @param hg_gated Set to TRUE if the accessed model is gated.
-#' @param hg_token The token needed to access the gated model generated in huggingface website.
+#' @param hg_token The token needed to access the gated model.
+#' Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+#' the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+#' be set to avoid the need to enter the token each time.
 #' @return Number of layers.
 #' @examples
 #' \dontrun{

--- a/R/0_3_textModels.R
+++ b/R/0_3_textModels.R
@@ -32,7 +32,10 @@ textModels <- function() {
 #' @seealso see \code{\link{textModels}}
 #' @importFrom reticulate source_python
 #' @export
-textModelLayers <- function(target_model, hg_gated = FALSE, hg_token = "") {
+textModelLayers <- function(target_model,
+                            hg_gated = FALSE,
+                            hg_token = Sys.getenv("HUGGINGFACE_TOKEN",
+                                                  unset = "")) {
   reticulate::source_python(system.file("python",
     "huggingface_Interface3.py",
     package = "text",

--- a/R/1_1_textEmbed.R
+++ b/R/1_1_textEmbed.R
@@ -351,7 +351,10 @@ textTokenize <- function(texts,
 #' @param max_token_to_sentence (numeric) Maximum number of tokens in a string to handle before
 #'  switching to embedding text sentence by sentence. (default= 4)
 #' @param hg_gated Set to TRUE if the accessed model is gated.
-#' @param hg_token The token needed to access the gated model generated in huggingface website.
+#' @param hg_token The token needed to access the gated model.
+#' Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+#' the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+#' be set to avoid the need to enter the token each time.
 #' @param logging_level (character) Set the logging level. (default ="error")
 #' Options (ordered from less logging to more logging): critical, error, warning, info, debug
 #' @param sort (boolean) If TRUE sort the output to tidy format. (default = TRUE)
@@ -967,7 +970,10 @@ generate_placement_vector <- function(raw_layers, texts) {
 #' @param device Name of device to use: 'cpu', 'gpu', 'gpu:k' or 'mps'/'mps:k' for MacOS, where k is a
 #' specific device number such as 'mps:1'.
 #' @param hg_gated Set to TRUE if the accessed model is gated.
-#' @param hg_token The token to access the gated model generated in huggingface website.
+#' @param hg_token The token needed to access the gated model.
+#' Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+#' the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+#' be set to avoid the need to enter the token each time.
 #' @param logging_level Set the logging level. Default: "warning".
 #' Options (ordered from less logging to more logging): critical, error, warning, info, debug
 #' @param ... settings from textEmbedRawLayers().

--- a/R/1_1_textEmbed.R
+++ b/R/1_1_textEmbed.R
@@ -387,7 +387,8 @@ textEmbedRawLayers <- function(texts,
                                model_max_length = NULL,
                                max_token_to_sentence = 4,
                                hg_gated = FALSE,
-                               hg_token = "",
+                               hg_token = Sys.getenv("HUGGINGFACE_TOKEN",
+                                                     unset = ""),
                                logging_level = "error",
                                sort = TRUE) {
   if (decontextualize == TRUE && word_type_embeddings == FALSE) {
@@ -894,10 +895,10 @@ generate_placement_vector <- function(raw_layers, texts) {
 
     # Check if "na" or "" is present in any element of the list
     if ((((any(sapply(elements, function(element) "na" %in% element)) ||
-         any(sapply(elements, function(element) "NA" %in% element))) && 
-         nrow(token_embedding) == 3))|| 
+         any(sapply(elements, function(element) "NA" %in% element))) &&
+         nrow(token_embedding) == 3))||
          nrow(token_embedding) == 2){
-       
+
       # If so, then check for "na" (or "") in the token-embedding
       if (any(grepl("na", token_embedding$tokens, ignore.case = TRUE)) ||
           any(grepl("NA", token_embedding$tokens, ignore.case = TRUE)) ||
@@ -1019,7 +1020,8 @@ textEmbed <- function(texts,
                       tokenizer_parallelism = FALSE,
                       device = "cpu",
                       hg_gated = FALSE,
-                      hg_token = "",
+                      hg_token = Sys.getenv("HUGGINGFACE_TOKEN",
+                                            unset = ""),
                       logging_level = "error",
                       ...) {
   if (sum(is.na(texts) > 0)) {

--- a/man/textEmbed.Rd
+++ b/man/textEmbed.Rd
@@ -21,7 +21,7 @@ textEmbed(
   tokenizer_parallelism = FALSE,
   device = "cpu",
   hg_gated = FALSE,
-  hg_token = "",
+  hg_token = Sys.getenv("HUGGINGFACE_TOKEN", unset = ""),
   logging_level = "error",
   ...
 )

--- a/man/textEmbed.Rd
+++ b/man/textEmbed.Rd
@@ -84,7 +84,10 @@ specific device number such as 'mps:1'.}
 
 \item{hg_gated}{Set to TRUE if the accessed model is gated.}
 
-\item{hg_token}{The token to access the gated model generated in huggingface website.}
+\item{hg_token}{The token needed to access the gated model.
+Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+be set to avoid the need to enter the token each time.}
 
 \item{logging_level}{Set the logging level. Default: "warning".
 Options (ordered from less logging to more logging): critical, error, warning, info, debug}

--- a/man/textEmbedRawLayers.Rd
+++ b/man/textEmbedRawLayers.Rd
@@ -18,7 +18,7 @@ textEmbedRawLayers(
   model_max_length = NULL,
   max_token_to_sentence = 4,
   hg_gated = FALSE,
-  hg_token = "",
+  hg_token = Sys.getenv("HUGGINGFACE_TOKEN", unset = ""),
   logging_level = "error",
   sort = TRUE
 )

--- a/man/textEmbedRawLayers.Rd
+++ b/man/textEmbedRawLayers.Rd
@@ -68,7 +68,10 @@ switching to embedding text sentence by sentence. (default= 4)}
 
 \item{hg_gated}{Set to TRUE if the accessed model is gated.}
 
-\item{hg_token}{The token needed to access the gated model generated in huggingface website.}
+\item{hg_token}{The token needed to access the gated model.
+Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+be set to avoid the need to enter the token each time.}
 
 \item{logging_level}{(character) Set the logging level. (default ="error")
 Options (ordered from less logging to more logging): critical, error, warning, info, debug}

--- a/man/textModelLayers.Rd
+++ b/man/textModelLayers.Rd
@@ -4,7 +4,11 @@
 \alias{textModelLayers}
 \title{Get the number of layers in a given model.}
 \usage{
-textModelLayers(target_model, hg_gated = FALSE, hg_token = "")
+textModelLayers(
+  target_model,
+  hg_gated = FALSE,
+  hg_token = Sys.getenv("HUGGINGFACE_TOKEN", unset = "")
+)
 }
 \arguments{
 \item{target_model}{(string) The name of the model to know the number of layers of.}

--- a/man/textModelLayers.Rd
+++ b/man/textModelLayers.Rd
@@ -15,7 +15,10 @@ textModelLayers(
 
 \item{hg_gated}{Set to TRUE if the accessed model is gated.}
 
-\item{hg_token}{The token needed to access the gated model generated in huggingface website.}
+\item{hg_token}{The token needed to access the gated model.
+Create a token from the ['Settings' page](https://huggingface.co/settings/tokens) of
+the Hugging Face website. An an environment variable HUGGINGFACE_TOKEN can
+be set to avoid the need to enter the token each time.}
 }
 \value{
 Number of layers.


### PR DESCRIPTION
See https://github.com/OscarKjell/text/issues/146 

Functionality has been added to enable users to access gated HF models by specifying a token, as in `textEmbed(hg_token = "some_token")`

This PR enables users to store this token as an environment variable, rather than requiring them to specify it in each call to `textEmbed()` or similar functions when using gated models. The default token remains the empty string `""`. Users are still able to supply the token manually when invoking the function if they wish.

@moomoofarm1 