### PR TITLE
if aggregation_from_tokens_to_word_types is set to individually, then…

### DIFF
--- a/R/0_2_privateFunctions.R
+++ b/R/0_2_privateFunctions.R
@@ -772,7 +772,10 @@ update_user_and_texts <- function(df) {
   has_story_id <- "story_id" %in% names(df)
   
   for (i in seq_along(df$participant_id)) {
-    sentences <- stringi::stri_split(df$texts[i], regex = "[.!?]", simplify = TRUE)
+    sentences <- stringi::stri_split_regex(df$texts[i], 
+                                  pattern = "(?<!\\bMr|\\bMrs|\\bMiss)[.!?]", 
+                                  simplify = TRUE)
+    
     sentences <- sentences[sentences != ""]
     
     current_user_id <- rep(df$participant_id[i], length(sentences))

--- a/R/1_1_textEmbed.R
+++ b/R/1_1_textEmbed.R
@@ -1179,7 +1179,7 @@ textEmbed <- function(texts,
         tokens_deselect = tokens_deselect
       )
       
-      # Switch back aggregation_from_tokens_to_word_types 
+      # Switch back aggregation_from_tokens_to_word_type 
       if (aggregation_from_tokens_to_word_types == "individually"){
         aggregation_from_tokens_to_texts = original_aggregation_from_tokens_to_texts
       }

--- a/man/textEmbed.Rd
+++ b/man/textEmbed.Rd
@@ -52,11 +52,14 @@ see \code{\link{textDimName}} to change names back and forth.}
 contextualized layers (e.g., "mean", "min" or "max, which takes the minimum, maximum or mean, respectively,
 across each column; or "concatenate", which links  together each word embedding layer to one long row.}
 
-\item{aggregation_from_tokens_to_texts}{(string)  Aggregates to the individual text (i.e., the aggregation of
-all tokens/words given to the transformer).}
+\item{aggregation_from_tokens_to_texts}{(string) Method to carry out the aggregation among the word embeddings
+for the words/tokens, including "min", "max" and "mean" which takes the minimum, maximum or mean across each column;
+or "concatenate", which links together each layer of the word embedding to one long row (default = "mean"). If set to NULL, embeddings are not 
+aggregated.}
 
 \item{aggregation_from_tokens_to_word_types}{(string) Aggregates to the word type (i.e., the individual words)
-rather than texts.}
+rather than texts. If set to "individually", then duplicate words are not aggregated, (i.e, the context of individual
+is preserved). (default = NULL).}
 
 \item{keep_token_embeddings}{(boolean) Whether to also keep token embeddings when using texts or word
 types aggregation.}

--- a/tests/testthat/test_2_5_textPredict.R
+++ b/tests/testthat/test_2_5_textPredict.R
@@ -93,7 +93,7 @@ test_that("1. textPredict generates embeddings from text and 2. automatically co
   testthat::expect_equal(predictions$person_predictions$person_prob[40], 0.1658826, tolerance = 0.0001)
   
   # Observe; when converting to numeric, zeros are replaced by ones, and ones are replaced by twos.  
-  
+
   # sentence predictions
   testthat::expect_equal(as.numeric(predictions$sentence_predictions$power_class[24]), 1, tolerance = 0.0001)
   testthat::expect_equal(sum(as.numeric(predictions$sentence_predictions$power_class)), 190, tolerance = 0.0001)


### PR DESCRIPTION
… the context of each word_type will be preserved and word_types will not be aggregated